### PR TITLE
fixed nullptr dereference

### DIFF
--- a/examples/1_SimpleTestShapes/1_SimpleTestShapes.ino
+++ b/examples/1_SimpleTestShapes/1_SimpleTestShapes.ino
@@ -108,7 +108,7 @@ void setup() {
   myWHITE = dma_display->color565(255, 255, 255);
   myRED = dma_display->color565(255, 0, 0);
   myGREEN = dma_display->color565(0, 255, 0);
-  myBLUE = dma_disdisplay->color565(0, 0, 255);
+  myBLUE = dma_display->color565(0, 0, 255);
   
 
   dma_display->fillScreen(myWHITE);

--- a/examples/1_SimpleTestShapes/1_SimpleTestShapes.ino
+++ b/examples/1_SimpleTestShapes/1_SimpleTestShapes.ino
@@ -13,13 +13,7 @@
 //MatrixPanel_I2S_DMA dma_display;
 MatrixPanel_I2S_DMA *dma_display = nullptr;
 
-uint16_t myBLACK = dma_display->color565(0, 0, 0);
-uint16_t myWHITE = dma_display->color565(255, 255, 255);
-uint16_t myRED = dma_display->color565(255, 0, 0);
-uint16_t myGREEN = dma_display->color565(0, 255, 0);
-uint16_t myBLUE = dma_display->color565(0, 0, 255);
-
-
+uint16_t myBLACK, myWHITE, myRED, myGREEN, myBLUE;
 
 // Input a value 0 to 255 to get a color value.
 // The colours are a transition r - g - b - back to r.
@@ -109,6 +103,14 @@ void setup() {
   dma_display->begin();
   dma_display->setBrightness8(90); //0-255
   dma_display->clearScreen();
+
+  myBLACK = dma_display->color565(0, 0, 0);
+  myWHITE = dma_display->color565(255, 255, 255);
+  myRED = dma_display->color565(255, 0, 0);
+  myGREEN = dma_display->color565(0, 255, 0);
+  myBLUE = dma_disdisplay->color565(0, 0, 255);
+  
+
   dma_display->fillScreen(myWHITE);
   
   // fix the screen with green

--- a/examples/3_DoubleBuffer/3_DoubleBuffer.ino
+++ b/examples/3_DoubleBuffer/3_DoubleBuffer.ino
@@ -5,16 +5,15 @@
 // Double buffering is not always required in reality.
 
 #include <ESP32-HUB75-MatrixPanel-I2S-DMA.h>
+#include <array>
 
 MatrixPanel_I2S_DMA *display = nullptr;
 
-uint16_t myDARK = display->color565(64, 64, 64);
-uint16_t myWHITE = display->color565(192, 192, 192);
-uint16_t myRED = display->color565(255, 0, 0);
-uint16_t myGREEN = display->color565(0, 255, 0);
-uint16_t myBLUE = display->color565(0, 0, 255);
+constexpr std::size_t color_num = 5;
+using colour_arr_t = std::array<uint16_t, color_num>;
 
-uint16_t colours[5] = { myDARK, myWHITE, myRED, myGREEN, myBLUE };
+uint16_t myDARK, myWHITE, myRED, myGREEN, myBLUE;
+colour_arr_t colours;
 
 struct Square
 {
@@ -44,6 +43,14 @@ void setup()
   // OK, now we can create our matrix object
   display = new MatrixPanel_I2S_DMA(mxconfig);
   display->begin();  // setup display with pins as pre-defined in the library
+
+  myDARK = display->color565(64, 64, 64);
+  myWHITE = display->color565(192, 192, 192);
+  myRED = display->color565(255, 0, 0);
+  myGREEN = display->color565(0, 255, 0);
+  myBLUE = display->color565(0, 0, 255);
+
+  colours = {{ myDARK, myWHITE, myRED, myGREEN, myBLUE }};
 
   // Create some random squares
   for (int i = 0; i < numSquares; i++)


### PR DESCRIPTION
a) fixed nullptr dereference in example 1 for Arduino framework
b) fixed nullptr dereference in example 3 for Arduino framework
c) rearranged example 3 a bit

examples run on my device and worked well - I would recommend  to test it before merging anyway

this pull request does not mean, that another files / examples dont require changes, took a quick peek into the examples and thats all, have a bread to earn :D

ref: https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/issues/675