### PR TITLE
esp32-S3 fix for crash in Bus_Parallel16::release()

### DIFF
--- a/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
@@ -294,6 +294,7 @@
     if (_i80_bus)
     {
       esp_lcd_del_i80_bus(_i80_bus);
+      _i80_bus = nullptr;
     }
     if (_dmadesc_a)
     {

--- a/src/platforms/esp32s3/gdma_lcd_parallel16.hpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.hpp
@@ -169,7 +169,7 @@
     bool    _double_dma_buffer = false;
     //bool    _dmadesc_a_active   = true;    
 
-    esp_lcd_i80_bus_handle_t _i80_bus;
+    esp_lcd_i80_bus_handle_t _i80_bus = nullptr;
 
 
   };


### PR DESCRIPTION
This fixes crashes i got during `delete dma_display`.

🤔 It looks like  `_i80_bus` is not referenced anywhere else in the code, so you might even prefer to delete it.


Backtrace
```gdb
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.

Core  1 register dump:
PC      : 0x42101d72  PS      : 0x00060c30  A0      : 0x820c907a  A1      : 0x3fcebca0  
A2      : 0x0a2e6c65  A3      : 0x00000001  A4      : 0x00000000  A5      : 0x0000ff00
A6      : 0x00ff0000  A7      : 0xff000000  A8      : 0x820d2398  A9      : 0x3fcebc80  
A10     : 0x00000001  A11     : 0x00000000  A12     : 0x00000000  A13     : 0x00000000
A14     : 0x3fcefd14  A15     : 0x00000000  SAR     : 0x00000003  EXCCAUSE: 0x0000001c  
EXCVADDR: 0x0a2e6ca1  LBEG    : 0x400556d5  LEND    : 0x400556e5  LCOUNT  : 0xffffffff


Backtrace: 0x42101d6f:0x3fcebca0 0x420c9077:0x3fcebcd0 0x42017db5:0x3fcebcf0 0x420437a6:0x3fcebd20 0x42043948:0x3fcebd40 0x42043736:0x3fcebd60 0x4209f7f4:0x3fcebd80 0x4209ffd6:0x3fcebdb0 0x420d2879:0x3fcebdd0

  #0  0x42101d6f:0x3fcebca0 in esp_lcd_del_i80_bus at /Users/ficeto/Desktop/ESP32/ESP32S2/esp-idf-public/components/esp_lcd/src/esp_lcd_panel_io_i80.c:211 (discriminator 5)
  #1  0x420c9077:0x3fcebcd0 in Bus_Parallel16::release() at .pio/libdeps/my_esp32S3_16MB_PSRAM_M/ESP32 HUB75 LED MATRIX PANEL DMA Display/src/platforms/esp32s3/gdma_lcd_parallel16.cpp:296
  #2  0x42017db5:0x3fcebcf0 in MatrixPanel_I2S_DMA::~MatrixPanel_I2S_DMA() at .pio/libdeps/my_esp32S3_16MB_PSRAM_M/ESP32 HUB75 LED MATRIX PANEL DMA Display/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h:475 
      (inlined by) MatrixPanel_I2S_DMA::~MatrixPanel_I2S_DMA() at .pio/libdeps/my_esp32S3_16MB_PSRAM_M/ESP32 HUB75 LED MATRIX PANEL DMA Display/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h:476
  #3  0x420437a6:0x3fcebd20 in BusHub75Matrix::cleanup() at wled00/bus_manager.cpp:1008 (discriminator 2)


ELF file SHA256: 67cbdee5cf6cf8ae

Rebooting...
�ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0xc (RTC_SW_CPU_RST),boot:0x2b (SPI_FAST_FLASH_BOOT)
Saved PC:0x42164f92
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fce3808,len:0x44c
load:0x403c9700,len:0xbe4
load:0x403cc700,len:0x2a38
entry 0x403c98d4
[   382][I][esp32-hal-psram.c:96] psramInit(): PSRAM enabled
```