### PR TITLE
Update deprecated function in gdma_lcd_parallel16.cpp and dma_parallel_io.cpp

### DIFF
--- a/src/platforms/esp32c6/dma_parallel_io.cpp
+++ b/src/platforms/esp32c6/dma_parallel_io.cpp
@@ -140,11 +140,16 @@ bool Bus_Parallel16::init(void)
         .auto_update_desc = false};
     gdma_apply_strategy(dma_chan, &strategy_config);
 
-    gdma_transfer_ability_t ability = {
-        .sram_trans_align = 32,
-        .psram_trans_align = 64,
+    gdma_transfer_config_t transfer_config = {
+#ifdef SPIRAM_DMA_BUFFER
+      .max_data_burst_size = 64,
+      .access_ext_mem = true
+#else
+      .max_data_burst_size = 32,
+      .access_ext_mem = false
+#endif
     };
-    gdma_set_transfer_ability(dma_chan, &ability);
+    gdma_config_transfer(dma_chan, &transfer_config);
 
     // Enable DMA transfer callback
     static gdma_tx_event_callbacks_t tx_cbs = {

--- a/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
@@ -256,11 +256,16 @@
     };
     gdma_apply_strategy(dma_chan, &strategy_config);
 
-    gdma_transfer_ability_t ability = {
-        .sram_trans_align = 32,
-        .psram_trans_align = 64,
+    gdma_transfer_config_t transfer_config = {
+#ifdef SPIRAM_DMA_BUFFER
+      .max_data_burst_size = 64,
+      .access_ext_mem = true
+#else
+      .max_data_burst_size = 32,
+      .access_ext_mem = false
+#endif
     };
-    gdma_set_transfer_ability(dma_chan, &ability);    
+    gdma_config_transfer(dma_chan, &transfer_config);    
 
     // Enable DMA transfer callback
     static gdma_tx_event_callbacks_t tx_cbs = {


### PR DESCRIPTION
In Arduino 3.1.0 and ESP-IDF 5.3 gdma_set_transfer_ability is deprecated and should be replaced with gdma_config_transfer