### PR TITLE
Guard new gdma_config_transfer to allow building with ESP-IDF < 5.4.0

### DIFF
--- a/src/platforms/esp32c6/dma_parallel_io.cpp
+++ b/src/platforms/esp32c6/dma_parallel_io.cpp
@@ -140,6 +140,7 @@ bool Bus_Parallel16::init(void)
         .auto_update_desc = false};
     gdma_apply_strategy(dma_chan, &strategy_config);
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     gdma_transfer_config_t transfer_config = {
 #ifdef SPIRAM_DMA_BUFFER
       .max_data_burst_size = 64,
@@ -150,6 +151,13 @@ bool Bus_Parallel16::init(void)
 #endif
     };
     gdma_config_transfer(dma_chan, &transfer_config);
+#else
+    gdma_transfer_ability_t ability = {
+        .sram_trans_align = 32,
+        .psram_trans_align = 64,
+    };
+    gdma_set_transfer_ability(dma_chan, &ability);
+#endif
 
     // Enable DMA transfer callback
     static gdma_tx_event_callbacks_t tx_cbs = {

--- a/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
@@ -256,6 +256,7 @@
     };
     gdma_apply_strategy(dma_chan, &strategy_config);
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
     gdma_transfer_config_t transfer_config = {
 #ifdef SPIRAM_DMA_BUFFER
       .max_data_burst_size = 64,
@@ -265,7 +266,14 @@
       .access_ext_mem = false
 #endif
     };
-    gdma_config_transfer(dma_chan, &transfer_config);    
+    gdma_config_transfer(dma_chan, &transfer_config);
+#else
+    gdma_transfer_ability_t ability = {
+        .sram_trans_align = 32,
+        .psram_trans_align = 64,
+    };
+    gdma_set_transfer_ability(dma_chan, &ability);
+#endif
 
     // Enable DMA transfer callback
     static gdma_tx_event_callbacks_t tx_cbs = {


### PR DESCRIPTION
Partially reverts #718 for framework versions < 5.4.0.

This allow using the library with the current [PlatformIO v6.9.0](https://github.com/platformio/platform-espressif32/releases/tag/v6.9.0) which only supports Arduino v2.0.17 (based on IDF v4.4.7) and ESP-IDF v5.3.1.