### PR TITLE
Remove duplicate Arduino.h import from esp32c6 dma_parallel_io.cpp

### DIFF
--- a/src/platforms/esp32c6/dma_parallel_io.cpp
+++ b/src/platforms/esp32c6/dma_parallel_io.cpp
@@ -1,5 +1,4 @@
 #include "dma_parallel_io.hpp"
-#include <Arduino.h>
 
 #ifdef CONFIG_IDF_TARGET_ESP32C6
 


### PR DESCRIPTION
The esp32c6 DMA Parallel IO implementation includes Arduino.h in the second line, and then later on, with the correct ifdef-gates. This removes that first line because it causes issues when building with esp-idf also for other targets.