### PR TITLE
Settable pixel-base

### DIFF
--- a/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -56,7 +56,8 @@ enum PANEL_SCAN_RATE
     NORMAL_ONE_SIXTEEN, // treated as the same
     FOUR_SCAN_32PX_HIGH,
     FOUR_SCAN_16PX_HIGH,
-    FOUR_SCAN_64PX_HIGH
+    FOUR_SCAN_64PX_HIGH,
+    FOUR_SCAN_40PX_HIGH
 };
 
 // Chaining approach... From the perspective of the DISPLAY / LED side of the chain of panels.
@@ -412,6 +413,13 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t virt_x, int16_t virt_
                 // 2nd, 4th 'block' of 8 rows of pixels, offset by panel width in DMA buffer
                 coords.x += (coords.x / panelResX) * panelResX;
             coords.y = (coords.y >> 3) * 4 + (coords.y & 0b00000011);
+            break;
+        case FOUR_SCAN_40PX_HIGH:
+            if ((coords.y / 10) % 2 == 0)
+                coords.x += ((coords.x / panelResX) + 1) * panelResX;
+            else
+                coords.x += (coords.x / panelResX) * panelResX;
+            coords.y = (coords.y / 20) * 10 + (coords.y % 10);
             break;
         default:
             break;

--- a/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -97,6 +97,7 @@ public:
 
         panelResX = _panelResX;
         panelResY = _panelResY;
+        panel_pixel_base = _panelResX;
 
         vmodule_rows = _vmodule_rows;
         vmodule_cols = _vmodule_cols;
@@ -150,12 +151,14 @@ public:
     void drawDisplayTest();
 
     void setPhysicalPanelScanRate(PANEL_SCAN_RATE rate);
+    void setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, int16_t pixel_base);
 	void setZoomFactor(int scale);
 
     virtual VirtualCoords getCoords(int16_t x, int16_t y);
     VirtualCoords coords;
     int16_t panelResX;
     int16_t panelResY;
+    int16_t panel_pixel_base;
 
 private:
     MatrixPanel_I2S_DMA *display;
@@ -395,10 +398,10 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t virt_x, int16_t virt_
 
             if ((coords.y & 8) == 0)
                 // 1st, 3rd 'block' of 8 rows of pixels, offset by panel width in DMA buffer
-                coords.x += ((coords.x / panelResX) + 1) * panelResX;
+                coords.x += ((coords.x / panel_pixel_base) + 1) * panel_pixel_base;
             else
                 // 2nd, 4th 'block' of 8 rows of pixels, offset by panel width in DMA buffer
-                coords.x += (coords.x / panelResX) * panelResX;
+                coords.x += (coords.x / panel_pixel_base) * panel_pixel_base;
 
             // http://cpp.sh/4ak5u
             // Real number of DMA y rows is half reality
@@ -408,17 +411,17 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t virt_x, int16_t virt_
         case FOUR_SCAN_16PX_HIGH:
             if ((coords.y & 4) == 0)
                 // 1st, 3rd 'block' of 8 rows of pixels, offset by panel width in DMA buffer
-                coords.x += ((coords.x / panelResX) + 1) * panelResX;
+                coords.x += ((coords.x / panel_pixel_base) + 1) * panel_pixel_base;
             else
                 // 2nd, 4th 'block' of 8 rows of pixels, offset by panel width in DMA buffer
-                coords.x += (coords.x / panelResX) * panelResX;
+                coords.x += (coords.x / panel_pixel_base) * panel_pixel_base;
             coords.y = (coords.y >> 3) * 4 + (coords.y & 0b00000011);
             break;
         case FOUR_SCAN_40PX_HIGH:
             if ((coords.y / 10) % 2 == 0)
-                coords.x += ((coords.x / panelResX) + 1) * panelResX;
+                coords.x += ((coords.x / panel_pixel_base) + 1) * panel_pixel_base;
             else
-                coords.x += (coords.x / panelResX) * panelResX;
+                coords.x += (coords.x / panel_pixel_base) * panel_pixel_base;
             coords.y = (coords.y / 20) * 10 + (coords.y % 10);
             break;
         default:
@@ -522,6 +525,12 @@ inline void VirtualMatrixPanel::setRotation(uint8_t rotate)
 inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate)
 {
     panel_scan_rate = rate;
+}
+
+inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, int16_t pixel_base)
+{
+    panel_scan_rate = rate;
+    panel_pixel_base = pixel_base;
 }
 
 inline void VirtualMatrixPanel::setZoomFactor(int scale)

--- a/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -151,14 +151,14 @@ public:
     void drawDisplayTest();
 
     void setPhysicalPanelScanRate(PANEL_SCAN_RATE rate);
-    void setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, int16_t pixel_base);
+    void setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, uint8_t pixel_base);
 	void setZoomFactor(int scale);
 
     virtual VirtualCoords getCoords(int16_t x, int16_t y);
     VirtualCoords coords;
     uint8_t panelResX;
     uint8_t panelResY;
-    int16_t panel_pixel_base;
+    uint8_t panel_pixel_base;
 
 private:
     MatrixPanel_I2S_DMA *display;
@@ -527,7 +527,7 @@ inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate)
     panel_scan_rate = rate;
 }
 
-inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, int16_t pixel_base)
+inline void VirtualMatrixPanel::setPhysicalPanelScanRate(PANEL_SCAN_RATE rate, uint8_t pixel_base)
 {
     panel_scan_rate = rate;
     panel_pixel_base = pixel_base;


### PR DESCRIPTION
Review, test and merge #742, #748 and #746 first!
Adds ability to set pixel-base together with scan rate:
`setPhysicalPanelScanRate(rate, pixel_base);`
This will allow easier configuration of many outdoor displays without the need to override VirtualMatrixPanel.
@board707 you can use this to make a simplified example in #739 