### PR TITLE
ESP32-S3 | Move away from deprecated `gdma_new_channel`

### DIFF
--- a/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
+++ b/src/platforms/esp32s3/gdma_lcd_parallel16.cpp
@@ -211,7 +211,14 @@
         .reserve_sibling = 0
       }
     };
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 4, 0)
+    esp_err_t err = gdma_new_ahb_channel(&dma_chan_config, &dma_chan);
+    if (err != ESP_OK) {
+      ESP_LOGE("S3", "Failed to allocate AHB GDMA channel: %s", esp_err_to_name(err));
+    }
+#else
     gdma_new_channel(&dma_chan_config, &dma_chan);
+#endif
     gdma_connect(dma_chan, GDMA_MAKE_TRIGGER(GDMA_TRIG_PERIPH_LCD, 0));
     static gdma_strategy_config_t strategy_config = {
       .owner_check = false,


### PR DESCRIPTION
See espressif/esp-idf@39cbba3 

I do not have a C6 to test - but it should also be changed there.