### PR TITLE
Fix PSRAM DMA cache corruption, Add single scan

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -412,7 +412,8 @@ void IRAM_ATTR MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint16_t x_coord, uint
     p[x_coord] |= RGB_output_bits; // set new RGB bits
 
 #if defined(SPIRAM_DMA_BUFFER)
-    Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
+    // Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
+    esp_cache_msync( (void*)&p[x_coord], length, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
 
   } while (colour_depth_idx); // end of colour depth loop (8)
@@ -479,7 +480,8 @@ void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint8_t red, uint8_t green, uint
         p[x_coord] |= RGB_output_bits;     // set new colour bits
 
 #if defined(SPIRAM_DMA_BUFFER)
-        Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
+        // Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
+        esp_cache_msync( (void*)&p[x_coord], length, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
 
       } while (x_coord);
@@ -629,7 +631,8 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
     } while (colouridx);
 
 #if defined(SPIRAM_DMA_BUFFER)
-    Cache_WriteBack_Addr((uint32_t)row, fb->rowBits[row_idx]->getColorDepthSize(false));
+    // Cache_WriteBack_Addr((uint32_t)row, fb->rowBits[row_idx]->getColorDepthSize(false));
+    esp_cache_msync( (void*)row, fb->rowBits[row_idx]->getColorDepthSize(false), ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
 
   } while (row_idx);
@@ -696,7 +699,8 @@ void MatrixPanel_I2S_DMA::setBrightnessOE(uint8_t brt, const int _buff_id)
 	// Force the flush and update of the PSRAM for the memory address range of the 'row data' as
 	// data changes probably aren't being sent out via DMA as they're sitting in a hadrware 'cache' 
     ESP32_I2S_DMA_STORAGE_TYPE *row_ptr = fb->rowBits[row_idx]->getDataPtr(0);
-    Cache_WriteBack_Addr((uint32_t)row_ptr, fb->rowBits[row_idx]->getColorDepthSize(false));
+    // Cache_WriteBack_Addr((uint32_t)row_ptr, fb->rowBits[row_idx]->getColorDepthSize(false));
+    esp_cache_msync( (void*)row_ptr, fb->rowBits[row_idx]->getColorDepthSize(false)), ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
   } while (row_idx);
 }

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -413,7 +413,7 @@ void IRAM_ATTR MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint16_t x_coord, uint
 
 #if defined(SPIRAM_DMA_BUFFER)
     // Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
-    esp_cache_msync( (void*)&p[x_coord], length, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
+    esp_cache_msync( (void*)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE), ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
 
   } while (colour_depth_idx); // end of colour depth loop (8)
@@ -481,7 +481,7 @@ void MatrixPanel_I2S_DMA::updateMatrixDMABuffer(uint8_t red, uint8_t green, uint
 
 #if defined(SPIRAM_DMA_BUFFER)
         // Cache_WriteBack_Addr((uint32_t)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE));
-        esp_cache_msync( (void*)&p[x_coord], length, ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
+        esp_cache_msync( (void*)&p[x_coord], sizeof(ESP32_I2S_DMA_STORAGE_TYPE), ESP_CACHE_MSYNC_FLAG_DIR_C2M | ESP_CACHE_MSYNC_FLAG_TYPE_DATA | ESP_CACHE_MSYNC_FLAG_UNALIGNED );
 #endif
 
       } while (x_coord);

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -64,7 +64,11 @@
 #pragma message "You are not supposed to set MATRIX_ROWS_IN_PARALLEL. Setting it back to default."
 #undef MATRIX_ROWS_IN_PARALLEL
 #endif
+#ifdef MATRIX_ONE_SCAN
+#define MATRIX_ROWS_IN_PARALLEL 1
+#else
 #define MATRIX_ROWS_IN_PARALLEL 2
+#endif
 
 // 8bit per RGB color = 24 bit/per pixel,
 // can be extended to offer deeper colors, or

--- a/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
+++ b/src/ESP32-VirtualMatrixPanel-I2S-DMA.h
@@ -382,7 +382,7 @@ inline VirtualCoords VirtualMatrixPanel::getCoords(int16_t virt_x, int16_t virt_
         case FOUR_SCAN_64PX_HIGH:
             // https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA/issues/345#issuecomment-1510401192
             if ((virt_y & 8) != ((virt_y & 16) >> 1))
-                virt_y = (virt_y & 0b11000) ^ 0b11000 + (virt_y & 0b11100111);
+                virt_y = ((virt_y & 0b11000) ^ 0b11000) + (virt_y & 0b11100111);
             // no break, rest of code is the same for 64 and 32px high screens
         case FOUR_SCAN_32PX_HIGH:
             /* Convert Real World 'VirtualMatrixPanel' co-ordinates (i.e. Real World pixel you're looking at


### PR DESCRIPTION
1. Add 'MATRIX_ONE_SCAN' for single scan panels (like 64*32 panel with 1/32 scan rate)
2. Change Cache_WriteBack_Addr to esp_cache_msync with ESP_CACHE_MSYNC_FLAG_DIR_C2M, ESP_CACHE_MSYNC_FLAG_TYPE_DATA, ESP_CACHE_MSYNC_FLAG_UNALIGNED flags to avoid DMA memory corruption causes screen breaks during PSRAM/Flash writing