### PR TITLE
Add line_decoder field to the MXCONFIG with options (to fix issue #815)

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -514,13 +514,13 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
 	do
 	{
 		--x_pixel;
-		if (m_cfg.driver == HUB75_I2S_CFG::SM5266P)
+		if (m_cfg.line_decoder == HUB75_I2S_CFG::SM5266P)
 		{
 			// modifications here for row shift register type SM5266P
 			// https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/issues/164
 			row[x_pixel] = abcde & (0x18 << BITS_ADDR_OFFSET); // mask out the bottom 3 bits which are the clk di bk inputs
 		}
-		else if (m_cfg.driver == HUB75_I2S_CFG::DP3246_SM5368) 
+		else if (m_cfg.line_decoder  == HUB75_I2S_CFG::SM5368) 
 		{
 			row[ESP32_TX_FIFO_POSITION_ADJUST(x_pixel)] = 0x0000;
 		}
@@ -544,13 +544,13 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
     {
       --x_pixel;
 
-      if (m_cfg.driver == HUB75_I2S_CFG::SM5266P)
+      if (m_cfg.line_decoder == HUB75_I2S_CFG::SM5266P)
       {
         // modifications here for row shift register type SM5266P
         // https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/issues/164
         row[x_pixel] = abcde & (0x18 << BITS_ADDR_OFFSET); // mask out the bottom 3 bits which are the clk di bk inputs
       }
-      else if (m_cfg.driver == HUB75_I2S_CFG::DP3246_SM5368) 
+      else if (m_cfg.line_decoder  == HUB75_I2S_CFG::SM5368) 
       {
         row[ESP32_TX_FIFO_POSITION_ADJUST(x_pixel)] = 0x0000;
       }
@@ -563,7 +563,7 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
 
     // modifications here for row shift register type SM5266P
     // https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-I2S-DMA/issues/164
-    if (m_cfg.driver == HUB75_I2S_CFG::SM5266P)
+    if (m_cfg.line_decoder == HUB75_I2S_CFG::SM5266P)
     {
       uint16_t serialCount;
       uint16_t latch;
@@ -579,11 +579,11 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
     } // end SM5266P
 
     // row selection for SM5368 shift regs with ABC-only addressing. A is row clk, B is BK and C is row data
-    if (m_cfg.driver == HUB75_I2S_CFG::DP3246_SM5368) 
+    if (m_cfg.line_decoder == HUB75_I2S_CFG::SM5368) 
     {
       x_pixel = fb->rowBits[row_idx]->width - 1;                                                                        // last pixel in first block)
       uint16_t c = (row_idx == 0) ? BIT_C : 0x0000;                                                                     // set row data (C) when row==0, then push through shift regs for all other rows
-      row[ESP32_TX_FIFO_POSITION_ADJUST(x_pixel - 1)] |= c;                                                             // set row data
+      row[ESP32_TX_FIFO_POSITION_ADJUST(x_pixel - 1)] |= c | BIT_B;                                                            // set row data
       row[ESP32_TX_FIFO_POSITION_ADJUST(x_pixel + 0)] |= c | BIT_A | BIT_B;                                             // set row clk and bk, carry row data
     } // end DP3246_SM5368
 
@@ -598,7 +598,7 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
       row = fb->rowBits[row_idx]->getDataPtr(colouridx);
 
       // DP3246 needs the latch high for 3 clock cycles, so start 2 cycles earlier
-      if (m_cfg.driver == HUB75_I2S_CFG::DP3246_SM5368) 
+      if (m_cfg.driver == HUB75_I2S_CFG::DP3246) 
       {
         row[ESP32_TX_FIFO_POSITION_ADJUST(fb->rowBits[row_idx]->width - 3)] |= BIT_LAT;   // DP3246 needs 3 clock cycle latch 
         row[ESP32_TX_FIFO_POSITION_ADJUST(fb->rowBits[row_idx]->width - 2)] |= BIT_LAT;   // DP3246 needs 3 clock cycle latch 

--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -255,10 +255,17 @@ struct HUB75_I2S_CFG
     FM6126A,
     ICN2038S,
     MBI5124,
-    SM5266P,
-    DP3246_SM5368
+    DP3246
   };
 
+  enum line_driver
+  {
+    TYPE138 = 0,    // 3-to-8 decoder
+    TYPE595,        // shift register decoder
+    TYPE_DIRECT,    // direct row control 
+    SM5266P,        // shift register decoder with DE control
+    SM5368 = TYPE595
+  };
   /**
    * I2S clock speed selector
    */
@@ -292,6 +299,7 @@ struct HUB75_I2S_CFG
 
   // Matrix driver chip type - default is a plain shift register
   shift_driver driver;
+  line_driver line_decoder;
 
   // use DMA double buffer (twice as much RAM required)
   bool double_buff;
@@ -332,6 +340,7 @@ struct HUB75_I2S_CFG
           A_PIN_DEFAULT, B_PIN_DEFAULT, C_PIN_DEFAULT, D_PIN_DEFAULT, E_PIN_DEFAULT,
           LAT_PIN_DEFAULT, OE_PIN_DEFAULT, CLK_PIN_DEFAULT},
       shift_driver _drv = SHIFTREG, 
+      line_driver _line_drv = TYPE138,
       bool _dbuff = false, 
       clk_speed _i2sspeed = HZ_8M,
       uint8_t _latblk = DEFAULT_LAT_BLANKING, // Anything > 1 seems to cause artefacts on ICS panels

--- a/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-leddrivers.cpp
@@ -28,7 +28,7 @@ void MatrixPanel_I2S_DMA::shiftDriver(const HUB75_I2S_CFG& _cfg){
     case HUB75_I2S_CFG::FM6126A:
         fm6124init(_cfg);
         break;
-    case HUB75_I2S_CFG::DP3246_SM5368:
+    case HUB75_I2S_CFG::DP3246:
         dp3246init(_cfg);
         break;
     case HUB75_I2S_CFG::MBI5124:


### PR DESCRIPTION
As described in #815, the settings for led_driver and line_decoder chips should be independent in the MXCONFIG.

This PR offers an addition of `line_decoder` field to the MXCONFIG and created a new `line_driver` enum with decoder chips options. The option `DP3246_SM5368` was divided on two: `DP3246` driver and `SM5368` decoder settings. The variant `SM5266` was moved from drivers to decoders. All code occurrences of these options has changed consistently. 
A new decoder type `DIRECT_TYPE` added in the enum for future support of direct addressing (without real code yet).

To use a panel with a shift_register type decoders onebody has to add in the code the line:
```
mxconfig.line_decoder   = HUB75_I2S_CFG::SM5368;
```
or
```
mxconfig.line_decoder   = HUB75_I2S_CFG::TYPE595;   // the same as SM5368
```

Tested on the 80x40 s10 panel with TC7559 shift_register type line decoder (issue #806).