### PR TITLE
Add support of direct type line decoder.

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.cpp
@@ -506,6 +506,11 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
 
     ESP32_I2S_DMA_STORAGE_TYPE *row = fb->rowBits[row_idx]->getDataPtr(0); // set pointer to the HEAD of a buffer holding data for the entire matrix row
     ESP32_I2S_DMA_STORAGE_TYPE abcde = (ESP32_I2S_DMA_STORAGE_TYPE)row_idx;
+   
+    if (m_cfg.line_decoder == HUB75_I2S_CFG::TYPE_DIRECT)
+		{ 
+      abcde = 1 << abcde; 
+    }
 
     // get last pixel index in a row of all colourdepths
     int x_pixel = fb->rowBits[row_idx]->width * fb->rowBits[row_idx]->colour_depth;
@@ -539,6 +544,11 @@ void MatrixPanel_I2S_DMA::clearFrameBuffer(bool _buff_id)
 		abcde = row_idx-1;	
 	}
 
+  if (m_cfg.line_decoder == HUB75_I2S_CFG::TYPE_DIRECT)
+  { 
+    abcde = 1 << abcde; 
+  }
+  
     abcde <<= BITS_ADDR_OFFSET; // shift row y-coord to match ABCDE bits in vector from 8 to 12		
 	do
     {


### PR DESCRIPTION
The PR adds support for another method of switching lines on the panel - direct decoding. In this case, each ABCDE pin works as a switcher, turns on and off one of the lines. 
Obviously, the maximum scan with such decoding is equal to the number of ABCDE lines, that is, five (1/5s). However, in practice, I only came across panels with this method with a scan of 1/2 and 1/4.

Using the direct decoding in a code:
```
mxconfig.line_decoder   = HUB75_I2S_CFG::TYPE_DIRECT;
```
 Tested on 32x16 1/2s panel