### PR TITLE
Fix build issue with NO_GFX and NO_GFX_LITE

### DIFF
--- a/src/ESP32-HUB75-VirtualMatrixPanel_T.hpp
+++ b/src/ESP32-HUB75-VirtualMatrixPanel_T.hpp
@@ -207,6 +207,8 @@ public:
 	  : GFX(_vmodule_cols * _panel_res_x, _vmodule_rows * _panel_res_y),
 #elif !defined(NO_GFX)
 	  : Adafruit_GFX(_vmodule_cols * _panel_res_x, _vmodule_rows * _panel_res_y),
+#else
+	  :
 #endif
 		panel_res_x(_panel_res_x),
 		panel_res_y(_panel_res_y),
@@ -246,7 +248,7 @@ public:
 			display->drawPixel(coords.x, coords.y, color);			
 		}
 
-		log_v("x: %d, y: %d -> coords.x: %d, coords.y: %d", x, y, coords.x, coords.y);
+		//log_v("x: %d, y: %d -> coords.x: %d, coords.y: %d", x, y, coords.x, coords.y);
 	}
 
 	inline void fillScreen(uint16_t color) {


### PR DESCRIPTION
There is a missing : when building w/o USE_GFX_LITE and NO_GFX=1 and log_v doesn't work without arduino (I'm specifically building with esp-idf) so just commenting it out since it seems unnecessary and all of the other logs are.