### PR TITLE
examples/esp-idf/with-gfx: Add `--depth 1` to `git clone` command

### DIFF
--- a/examples/esp-idf/with-gfx/README.md
+++ b/examples/esp-idf/with-gfx/README.md
@@ -12,6 +12,6 @@ When you are ready to start your first project with this library, follow folow t
      git clone https://github.com/mrfaptastic/ESP32-HUB75-MatrixPanel-DMA.git components/ESP32-HUB75-MatrixPanel-I2S-DMA
      git clone https://github.com/adafruit/Adafruit-GFX-Library.git components/Adafruit-GFX-Library
      git clone https://github.com/adafruit/Adafruit_BusIO.git components/Adafruit_BusIO
-     git clone https://github.com/espressif/arduino-esp32.git components/arduino
+     git clone --depth 1 https://github.com/espressif/arduino-esp32.git components/arduino
      ```
   1. Build your project: `idf.py build`


### PR DESCRIPTION
Context: https://github.com/mrcodetastic/ESP32-HUB75-MatrixPanel-DMA/issues/798

Users are reporting that it's difficult to use the arduino-esp32 repo when building with esp-idf because of the size of that repo.  The repo contains over 2GB of revision data in the .git directory.

This PR updates the instructions to add `--depth 1` into the `git clone` command so that the resulting cloned repo is < 100MB instead of 2GB.