### PR TITLE
Add resumeDMAoutput() to resume DMA after stopDMAoutput()

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -707,13 +707,24 @@ public:
   }
 
   /**
-   * Stop the ESP32 DMA Engine. Screen will forever be black until next ESP reboot.
+   * Stop the ESP32 DMA Engine, keeping buffers and config intact so output can be
+   * resumed later via resumeDMAoutput(). Useful to reduce power draw / 'turn off' the
+   * panel when not in use, or to quiet its RF emissions during WiFi transfers.
    */
   void stopDMAoutput()
   {
     resetbuffers();
     // i2s_parallel_stop_dma(ESP32_I2S_DEVICE);
     dma_bus.dma_transfer_stop();
+  }
+
+  /**
+   * Resume DMA output after a stopDMAoutput() call.
+   * Note: stopDMAoutput() blanks the framebuffer (brightness is preserved), so redraw after.
+   */
+  void resumeDMAoutput()
+  {
+    dma_bus.dma_transfer_start();
   }
 
   // ------- PROTECTED -------


### PR DESCRIPTION
As discussed in #656.

`stopDMAoutput()` halts the DMA engine but, until now, there was no public way to start it again short of rebooting. This PR adds a `resumeDMAoutput()` method that calls the existing `dma_bus.dma_transfer_start()` (the same call `begin()` already uses to start output), so a stopped panel can be brought back without a reboot.

### Use cases
- Reduce power draw / 'turn off' the panel when not in use, then resume on demand.
- Quiet the panel's RF emissions during sensitive WiFi transfers (stop, fetch, resume), which noticeably improved my fetch reliability.

### Notes
- `stopDMAoutput()` blanks the framebuffer content (brightness is preserved via `resetbuffers()`), so callers should redraw after resuming.
- Doc comment on `stopDMAoutput()` updated (it previously said the screen stays black until reboot, which is no longer the case).