### PR TITLE
widen min_refresh_rate to uint16_t

### DIFF
--- a/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
+++ b/src/ESP32-HUB75-MatrixPanel-I2S-DMA.h
@@ -313,7 +313,7 @@ struct HUB75_I2S_CFG
 
   // Minimum refresh / scan rate needs to be configured on start due to LSBMSB_TRANSITION_BIT calculation in allocateDMAmemory()
   // Set this to '1' to get all colour depths displayed with correct BCM time weighting.
-  uint8_t min_refresh_rate;
+  uint16_t min_refresh_rate;
 
   // struct constructor
   HUB75_I2S_CFG(


### PR DESCRIPTION
Hi,
this pull request picks up on #338.
The min_refresh_rate was capped at an uint8_t limit at most before while the constructor took in an uint16_t limit at most. 
This is fixed now. :)

 